### PR TITLE
Don't verify the certificate when fetching

### DIFF
--- a/src/Punkstar/Ssl/Reader.php
+++ b/src/Punkstar/Ssl/Reader.php
@@ -13,7 +13,14 @@ class Reader
     {
         $urlHost = parse_url($url, PHP_URL_HOST);
 
-        $streamContext = stream_context_create(array("ssl" => array("capture_peer_cert" => TRUE)));
+        $streamContext = stream_context_create(array(
+            "ssl" => array(
+                "capture_peer_cert" => TRUE,
+                "verify_peer" => FALSE,
+                "verify_peer_name" => FALSE
+            )
+        ));
+
         $stream = stream_socket_client("ssl://" . $urlHost . ":443", $errno, $errstr, 30, STREAM_CLIENT_CONNECT, $streamContext);
         $streamParams = stream_context_get_params($stream);
 


### PR DESCRIPTION
This library is about reading certificates, not about verifying the certificates themselves.
